### PR TITLE
Allows for options parameter to not be sent

### DIFF
--- a/textFit.js
+++ b/textFit.js
@@ -43,6 +43,9 @@
   };
 
   return function textFit(els, options, callback) {
+    if(options == null){
+      options = {};
+    }
 
     if (typeof callback !== 'function') callback = function() {};
 


### PR DESCRIPTION
Some of the examples show textFit(...) called without the options parameter, but this results in an error when trying to call options.hasOwnProperty(key). This commit defaults the options param to an empty object if it isn't supplied.