### PR TITLE
Allow reprocess to shrink the font size

### DIFF
--- a/textFit.js
+++ b/textFit.js
@@ -121,12 +121,17 @@
     } else {
       // Reprocessing.
       innerSpan = el.querySelector('span.textFitted');
+      innerSpan.style['fontSize'] = '';
+
       // Remove vertical align if we're reprocessing.
       if (hasClass(innerSpan, 'textFitAlignVert')){
         innerSpan.className = innerSpan.className.replace('textFitAlignVert', '');
         innerSpan.style['height'] = '';
         el.className.replace('textFitAlignVertFlex', '');
       }
+
+      originalWidth = innerWidth(el);
+      originalHeight = innerHeight(el);
     }
 
     // Prepare & set alignment


### PR DESCRIPTION
I found that trying to reprocess wouldn't ever shrink the text size. This allows it to do that.